### PR TITLE
build target API 33 support and others improvement

### DIFF
--- a/ClientLib/build.gradle
+++ b/ClientLib/build.gradle
@@ -110,7 +110,7 @@ dependencies {
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'org.robolectric:robolectric:3.0'
     // Jai USB serial - start
-    implementation 'com.github.mik3y:usb-serial-for-android:3.5.1'
+    implementation 'com.github.mik3y:usb-serial-for-android:3.7.0'
     // Jai USB serial - end
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,9 +21,9 @@ android {
         applicationId 'arudpilot.andruav'
         minSdkVersion android_build_min_sdk_version
         targetSdkVersion android_build_target_sdk_version
-        versionName '5.05.00'
+        versionName '5.05.01'
         signingConfig signingConfigs.config
-        versionCode 50500
+        versionCode 50501
         multiDexEnabled true
 
         //testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,6 +73,11 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="29"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" /> <!-- Remote Access -->
+    <!-- API 33 and above start -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <!-- API 33 and above end-->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/app/src/main/java/ap/andruav_ap/helpers/CheckAppPermissions.java
+++ b/app/src/main/java/ap/andruav_ap/helpers/CheckAppPermissions.java
@@ -40,11 +40,21 @@ public abstract class CheckAppPermissions {
                     Manifest.permission.WRITE_EXTERNAL_STORAGE);
             //Log.d("CheckAppPermissions", "isPermissionsOK 1a = " + permissionsOK);
         }
-        else
+        else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
         {
             permissionsOK = CheckAppPermissions.checkPermission(activity,
                     Manifest.permission.READ_EXTERNAL_STORAGE);
             //Log.d("CheckAppPermissions", "isPermissionsOK 1b = " + permissionsOK);
+        }
+        else
+        {
+            //https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions
+            permissionsOK = CheckAppPermissions.checkPermission(activity,
+                    Manifest.permission.READ_MEDIA_AUDIO);
+            permissionsOK = permissionsOK && CheckAppPermissions.checkPermission(activity,
+                    Manifest.permission.READ_MEDIA_IMAGES);
+            permissionsOK = permissionsOK && CheckAppPermissions.checkPermission(activity,
+                    Manifest.permission.READ_MEDIA_IMAGES);
         }
         permissionsOK = permissionsOK && CheckAppPermissions.checkPermission(activity, Manifest.permission.CAMERA);
         permissionsOK = permissionsOK && CheckAppPermissions.checkPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION);

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ ext {
     play_services_version = '17.0.0'
     android_build_sdk_version = 33
     android_build_tools_version = '33.0.2'
-    android_build_target_sdk_version = 31
+    android_build_target_sdk_version = 33
     android_build_min_sdk_version = 24
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,6 @@ ANDROID_BUILD_TOOLS_VERSION=22.0.1
 ANDROID_BUILD_SDK_VERSION=22
 android.useAndroidX=true
 android.enableJetifier=true
-
+# Configuration cache ON, faster build - start
+org.gradle.configuration-cache=true
+# Configuration cache ON, faster build - end


### PR DESCRIPTION
[READ_EXTERNAL_STORAGE is deprecated](https://github.com/HefnySco/andruav_android_app/issues/25) (and is not granted) when targeting Android 13+.
If you need to query or interact with MediaStore or media files on the shared storage,
you should instead use one or more new storage permissions: READ_MEDIA_IMAGES,
READ_MEDIA_VIDEO or READ_MEDIA_AUDIO.

Build faster and upgrade 3rd party latest lib
upgrade usb-serial-for-android to 3.7.0
https://github.com/mik3y/usb-serial-for-android/releases
https://docs.gradle.org/current/userguide/configuration_cache.html